### PR TITLE
Rename utils methods

### DIFF
--- a/osu.Game.Rulesets.Cytosu/Beatmaps/CytosuBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Cytosu/Beatmaps/CytosuBeatmapConverter.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Cytosu.Beatmaps
 
         protected override IEnumerable<CytosuHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
         {
-            var progression = CytosuUtils.GetYProgressionFromBeatmap(beatmap, original.StartTime);
+            var progression = CytosuUtils.GetProgressionFromBeatmap(beatmap, original.StartTime);
 
             float x = ((IHasXPosition)original).X;
             float y = progression * 384;

--- a/osu.Game.Rulesets.Cytosu/UI/ScanLine.cs
+++ b/osu.Game.Rulesets.Cytosu/UI/ScanLine.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Cytosu.UI
         {
             float beatProgression = (float)(TimeSinceLastBeat / (TimeSinceLastBeat + TimeUntilNextBeat));
 
-            return CytosuUtils.GetYProgression(beatIndex, beatProgression);
+            return CytosuUtils.GetProgression(beatIndex, beatProgression);
         }
     }
 }

--- a/osu.Game.Rulesets.Cytosu/UI/ScanLine.cs
+++ b/osu.Game.Rulesets.Cytosu/UI/ScanLine.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Cytosu.UI
         {
             float beatProgression = (float)(TimeSinceLastBeat / (TimeSinceLastBeat + TimeUntilNextBeat));
 
-            return CytosuUtils.GetProgression(beatIndex, beatProgression);
+            return CytosuUtils.GetProgressionFromBeat(beatIndex, beatProgression);
         }
     }
 }

--- a/osu.Game.Rulesets.Cytosu/Utils/CytosuUtils.cs
+++ b/osu.Game.Rulesets.Cytosu/Utils/CytosuUtils.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Cytosu.Utils
 {
     public static class CytosuUtils
     {
-        public static float GetYProgressionFromBeatmap(IBeatmap beatmap, double time)
+        public static float GetProgressionFromBeatmap(IBeatmap beatmap, double time)
         {
             var timingPoint = beatmap.ControlPointInfo.TimingPointAt(time);
             var timeSinceTimingPoint = time - timingPoint.Time;
@@ -17,10 +17,10 @@ namespace osu.Game.Rulesets.Cytosu.Utils
             float beatProgression = (float)(timeSinceTimingPoint % timingPoint.BeatLength / timingPoint.BeatLength);
             int beatIndex = (int)Math.Round((timeSinceTimingPoint - timeSinceTimingPoint % timingPoint.BeatLength) / timingPoint.BeatLength);
 
-            return GetYProgression(beatIndex, beatProgression);
+            return GetProgression(beatIndex, beatProgression);
         }
 
-        public static float GetYProgression(int beatIndex, float beatProgression)
+        public static float GetProgression(int beatIndex, float beatProgression)
         {
             if (beatIndex < 0)
             {

--- a/osu.Game.Rulesets.Cytosu/Utils/CytosuUtils.cs
+++ b/osu.Game.Rulesets.Cytosu/Utils/CytosuUtils.cs
@@ -17,10 +17,10 @@ namespace osu.Game.Rulesets.Cytosu.Utils
             float beatProgression = (float)(timeSinceTimingPoint % timingPoint.BeatLength / timingPoint.BeatLength);
             int beatIndex = (int)Math.Round((timeSinceTimingPoint - timeSinceTimingPoint % timingPoint.BeatLength) / timingPoint.BeatLength);
 
-            return GetProgression(beatIndex, beatProgression);
+            return GetProgressionFromBeat(beatIndex, beatProgression);
         }
 
-        public static float GetProgression(int beatIndex, float beatProgression)
+        public static float GetProgressionFromBeat(int beatIndex, float beatProgression)
         {
             if (beatIndex < 0)
             {


### PR DESCRIPTION
I think it's not necessary to keep Y in methods names, their usage could change in the future and it will be confusing.